### PR TITLE
Fixed-width grids & fix to non-modal picker panes

### DIFF
--- a/frameworks/desktop/panes/picker.js
+++ b/frameworks/desktop/panes/picker.js
@@ -547,6 +547,7 @@ SC.PickerPane = SC.PalettePane.extend({
   
   /** @private - click away picker. */
   modalPaneDidClick: function(evt) {
+    if (!this.get('isModal')) return YES; //Prevents the pane's surrounding divs from causing click-away behavior when they shouldn't.
     var f = this.get("frame");
     if(!this.clickInside(f, evt)) this.remove();
     return YES ; 

--- a/frameworks/desktop/views/grid.js
+++ b/frameworks/desktop/views/grid.js
@@ -31,6 +31,12 @@ SC.GridView = SC.ListView.extend(
     width of each item will be this value.
   */
   columnWidth: 64,
+  
+  /**
+    Set to YES if you don't want a row's items to stretch to fill the whole
+    row.  (Think text which is aligned to the left rather than justified.)
+  */
+  isFixedWidth: NO,
 
   /**
     The default example item view will render text-based items.
@@ -67,7 +73,7 @@ SC.GridView = SC.ListView.extend(
     var rowHeight = this.get('rowHeight') || 48,
         frameWidth = this.get('clippingFrame').width,
         itemsPerRow = this.get('itemsPerRow'),
-        columnWidth = Math.floor(frameWidth/itemsPerRow),
+        columnWidth = this.get('isFixedWidth') ? this.get('columnWidth') : Math.floor(frameWidth/itemsPerRow),
         row = Math.floor(contentIndex / itemsPerRow),
         col = contentIndex - (itemsPerRow*row) ;
     return { 

--- a/frameworks/foundation/views/view.js
+++ b/frameworks/foundation/views/view.js
@@ -947,7 +947,7 @@ SC.View = SC.Responder.extend(SC.DelegateSupport,
     @returns {void}
   */
   prepareContext: function(context, firstTime) {
-    var mixins, len, idx, layerId, bgcolor, cursor;
+    var mixins, len, idx, layerId, bgcolor, cursor, parentCursor;
   
     // do some initial setup only needed at create time.
     if (firstTime) {
@@ -975,10 +975,15 @@ SC.View = SC.Responder.extend(SC.DelegateSupport,
     cursor = this.get('cursor');
     if (!cursor && this.get('shouldInheritCursor')) {
       // If this view has no cursor and should inherit it from the parent, 
-      // then it sets its own cursor view.  This sets the cursor rather than 
-      // simply using the parent's cursor object so that its cursorless 
-      // childViews can also inherit it.
-      cursor = this.getPath('parentView.cursor');
+      // it inherits the cursor and saves to _inheritedCursor for posterity.
+      parentCursor = this.getPath('parentView.cursor');
+      if (!parentCursor) parentCursor = this.getPath('parentView._inheritedCursor');
+      if (parentCursor) {
+        this.set('_inheritedCursor', parentCursor);
+        cursor = parentCursor;
+      } else {
+        this.set('_inheritecCursor', null);
+      }
     }
 
     if (SC.typeOf(cursor) === SC.T_STRING) {
@@ -1138,6 +1143,12 @@ SC.View = SC.Responder.extend(SC.DelegateSupport,
     @property {Boolean}
   */
   shouldInheritCursor: YES,
+  
+  /** @private
+    This property is used to store cursors inherited from parents so that
+    they may be inherited by children.
+  */
+  _inheritedCursor: null,
   
   // ..........................................................
   // LAYER LOCATION

--- a/frameworks/foundation/views/view.js
+++ b/frameworks/foundation/views/view.js
@@ -982,7 +982,7 @@ SC.View = SC.Responder.extend(SC.DelegateSupport,
         this.set('_inheritedCursor', parentCursor);
         cursor = parentCursor;
       } else {
-        this.set('_inheritecCursor', null);
+        this.set('_inheritedCursor', null);
       }
     }
 


### PR DESCRIPTION
Sorry about the dual-featured, poorly-timed pull req but here are two straightforward enhancements.
- Fixed-width grids adds a new toggle which allows you to easily make your grid items not stretch to fill the line.  (I'm building an imitation file system view; I don't want the icons to spread out as the window is resized.)
- Currently, even if you set your picker panes to non-modal, they will still disappear if you click the modal background, which may be showing from a different picker pane.  This can result in things like unexpected and jarring partial dismissal.  This one-line fix prevents that behavior.
